### PR TITLE
Converting for loop to a Java Stream

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
+++ b/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
@@ -32,8 +32,8 @@ public final class CommentDatabase {
   private void getCommentsFromQuery() {
     PreparedQuery storedCommentsQuery = datastore.prepare(COMMENT_QUERY);
     this.comments = StreamSupport.stream(storedCommentsQuery.asIterable().spliterator(),  /*sequential execution*/ false)
-                                 .map(entity -> new Comment((String) entity.getProperty(AUTHOR_QUERY_STRING), 
-                                                       (String) entity.getProperty(VALUE_QUERY_STRING)))
+                                 .map(entity -> new Comment(entity.getProperty(AUTHOR_QUERY_STRING).toString(), 
+                                                            entity.getProperty(VALUE_QUERY_STRING).toString()))
                                  .collect(Collectors.toCollection(ArrayList::new));
   }
 

--- a/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
+++ b/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
@@ -6,6 +6,8 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import java.util.ArrayList;
+import java.util.stream.StreamSupport;
+import java.util.stream.Collectors;
 
 /* purpose: to manage the interface of the Datastore database used to store comments */
 public final class CommentDatabase {
@@ -29,11 +31,10 @@ public final class CommentDatabase {
 
   private void getCommentsFromQuery() {
     PreparedQuery storedCommentsQuery = datastore.prepare(COMMENT_QUERY);
-    this.comments = new ArrayList<Comment>();
-    for (Entity entity : storedCommentsQuery.asIterable()) {
-      Comment comment = new Comment((String) entity.getProperty(AUTHOR_QUERY_STRING), (String) entity.getProperty(VALUE_QUERY_STRING));
-      this.comments.add(comment);
-    }  
+    this.comments = StreamSupport.stream(storedCommentsQuery.asIterable().spliterator(),  /*sequential execution*/ false)
+                                 .map(entity -> new Comment((String) entity.getProperty(AUTHOR_QUERY_STRING), 
+                                                       (String) entity.getProperty(VALUE_QUERY_STRING)))
+                                 .collect(Collectors.toCollection(ArrayList::new));
   }
 
   public void putCommentInDatabase(Comment comment) {

--- a/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
+++ b/portfolio/src/main/java/com/google/sps/data/CommentDatabase.java
@@ -15,7 +15,7 @@ public final class CommentDatabase {
   public static final String AUTHOR_QUERY_STRING = "author";
   public static final String VALUE_QUERY_STRING = "value";
   public static final String TIME_QUERY_STRING = "timestamp";
-  private static final Query COMMENT_QUERY = new Query(COMMENT_QUERY_STRING).addSort(TIME_QUERY_STRING, SortDirection.ASCENDING);
+  private static final Query COMMENT_QUERY = new Query(COMMENT_QUERY_STRING).addSort(TIME_QUERY_STRING, SortDirection.DESCENDING);
   DatastoreService datastore;
   private ArrayList<Comment> comments;
 
@@ -26,16 +26,25 @@ public final class CommentDatabase {
   /* public wrappper method to return all comments from datastore as an arraylist */
   public ArrayList<Comment> getCommentsAsArrayList(){
     this.getCommentsFromQuery();
+    // sort so that comments are displayed from oldest to newest
     return this.comments;
   }
 
   private void getCommentsFromQuery() {
     PreparedQuery storedCommentsQuery = datastore.prepare(COMMENT_QUERY);
-    this.comments = StreamSupport.stream(storedCommentsQuery.asIterable().spliterator(),  /*sequential execution*/ false)
-                                 .map(entity -> new Comment(entity.getProperty(AUTHOR_QUERY_STRING).toString(), 
-                                                            entity.getProperty(VALUE_QUERY_STRING).toString()))
-                                 .collect(Collectors.toCollection(ArrayList::new));
+    // grab maxCommentsToDisplay newest comments
+    this.comments = 
+        StreamSupport
+            .stream(storedCommentsQuery.asIterable().spliterator(),  /*sequential execution*/ false)
+            .map(this::commentFromEntity)
+            .collect(Collectors.toCollection(ArrayList::new));
   }
+
+  private Comment commentFromEntity(Entity entity){
+      return new Comment(
+                 entity.getProperty(AUTHOR_QUERY_STRING).toString(), 
+                 entity.getProperty(VALUE_QUERY_STRING).toString());
+  } 
 
   public void putCommentInDatabase(Comment comment) {
       Entity commentEntity = getDatastoreEntityFromComment(comment);


### PR DESCRIPTION
The for loop that added each comment entity returned by a datastore query into an ArrayList of Comments has been replaced by a Java Stream.