### PR TITLE
Adding functionality to delete each comment

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -61,7 +61,7 @@ public class CommentsServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // if max comments submit button clicked, get input from max comments form 
-    if (!ParameterGetter.getParameter(request,  MAX_FORM_SUBMIT).isEmpty()) {
+    if (!ParameterGetter.getParameter(request, MAX_FORM_SUBMIT).isEmpty()) {
       handleMaxCommentRequest(request);
     }
     // if comment submit button clicked, get author and value from comments form

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
@@ -5,6 +5,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.sps.data.Comment;
 import com.google.sps.data.CommentDatabase;
+import com.google.sps.servlets.ParameterGetter;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -15,15 +16,27 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/delete-comment")
 public class DeleteCommentServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private static final String KEY_VALUE_TO_DELETE = "key-value";
+    private static final String COMMENTS_PAGE_URL = "/comments-page.html";
+    private static final String AUTHOR_VALUE_DELINEATOR = ":";
+    
     @Override
       public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        Comment comment = new Comment("hardcoded", "hardcoded"); // replace with getting user input from clicking a delete button
-        Key hardcodedKey = generateKey(comment);
-        datastore.delete(hardcodedKey);
+        String displayedComment = ParameterGetter.getParameter(request, KEY_VALUE_TO_DELETE);
+        Key commentKey = extractKeyFromDisplayedComment(displayedComment);
+        datastore.delete(commentKey);
+        response.sendRedirect(COMMENTS_PAGE_URL);
       }
-      
-      private Key generateKey(Comment comment) {
-        String keyString = comment.getAuthor() + comment.getValue();
+
+      private Key extractKeyFromDisplayedComment(String displayedComment) {
+        String[] authorAndValue = displayedComment.split(AUTHOR_VALUE_DELINEATOR, 2);
+        String author = authorAndValue[0].trim();  
+        String value = authorAndValue[1].trim();
+        return generateKeyFromAuthorValue(author, value);
+      }
+
+      private Key generateKeyFromAuthorValue(String author, String value) {
+        String keyString = author + value;
         return KeyFactory.createKey(CommentDatabase.COMMENT_QUERY_STRING, keyString);
       }
 }

--- a/portfolio/src/main/webapp/comments-page.html
+++ b/portfolio/src/main/webapp/comments-page.html
@@ -2,6 +2,7 @@
 <html>
   <head>
       <title>Comments</title>
+      <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
       <script src = "comments.js" type="text/javascript"> </script>
       <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Reenie+Beanie&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="style.css">
@@ -14,12 +15,12 @@
           <input type="text" name="author" required><br>
           <label for="value">Comment:</label><br>
           <input type="text" name="value" required><br>
-          <input type="submit" name = "comment-submit" value="Submit!" class="transparent-button">
+          <input type="submit" name="comment-submit" value="Submit!" class="transparent-button">
       </form>
       <p> How many comments do you want displayed? </p>
       <form action="/comments" method="POST">
           <input type="number" name="max-comments" min="0" max="100" required><br>
-          <input type="submit" name = "max-comment-submit" value="Submit!" class="transparent-button">
+          <input type="submit" name="max-comment-submit" value="Submit!" class="transparent-button">
       </form>
       <div id = "comments-container"></div>
   </body>

--- a/portfolio/src/main/webapp/comments.js
+++ b/portfolio/src/main/webapp/comments.js
@@ -14,19 +14,57 @@ function handleResponse(response) {
     commentListPromise.then(addCommentsToDom);
 }
 
-/* Adds authors and comments to html page, displaying author: comment */
+/* Adds authors and comments to html page, displaying author: comment.*/
 function addCommentsToDom(commentList) {
     const commentContainer = document.getElementById('comments-container');
     commentContainer.innerHTML = '';
     for (let i = 0; i < commentList.length; i++){
         commentContainer.appendChild(
-            createComment(commentList[i].author, commentList[i].value));
+            createCommentAndDeleteButton(commentList[i].author, commentList[i].value));
     }
 }
 
-/** Creates an <li> element containing author: comment. */
+/** creates a comment element with inline delete button */
+function createCommentAndDeleteButton(author, value) {
+  const commentWrapper = document.createElement('div');
+  commentWrapper.classList.add('comment_div');
+  const commentElement = createComment(author, value);
+  commentWrapper.appendChild(commentElement);
+  commentWrapper.appendChild(createDeleteButton(commentElement));
+  $('.comment_div li, .comment_div button').css('display', 'inline-block');
+  return commentWrapper;
+}
+
+/** Creates an <li> element containing author: comment.*/
 function createComment(author, value) {
   const liElement = document.createElement('li');
   liElement.innerText = author + ": " + value;
   return liElement;
+}
+
+/** Creates a delete button linked to the deletion of each comment */
+function createDeleteButton(commentElement) {
+  const deleteButton = document.createElement('form');
+  deleteButton.action = '/delete-comment';
+  deleteButton.method = 'GET';
+  deleteButton.appendChild(createSubmitButton());
+  deleteButton.appendChild(createKeyValueField(commentElement));
+  return deleteButton;
+}
+
+/** creates the submit button that triggers sending the "author:value" text of comment*/
+function createSubmitButton() {
+  const submitButton = document.createElement('input');
+  submitButton.type = 'submit';
+  submitButton.value = 'delete';
+  return submitButton;
+}
+
+/** sets the value to be sent as "author:value", which is used to identify comment for deletion */
+function createKeyValueField(commentElement) {
+  const keyValueOfComment = document.createElement('input');
+  keyValueOfComment.type = 'hidden';
+  keyValueOfComment.value = commentElement.innerText;
+  keyValueOfComment.name = 'key-value';
+  return keyValueOfComment;
 }


### PR DESCRIPTION
Clicking on the delete button next to each comment deletes it from the datastore: http://zoebaker-step-2020.appspot.com/comments-page.html

Note that this **only works for comments added after this PR**, as they are now identified with a key that is used to identify them again for deletion. I will work on deleting legacy comments that were put in before the key identification. 