### PR TITLE
Display names are now stored in a datastore and accessed through a query

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/UserDatabase.java
+++ b/portfolio/src/main/java/com/google/sps/data/UserDatabase.java
@@ -1,20 +1,41 @@
 package com.google.sps.data;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.DatastoreService;
 
 public final class UserDatabase {
-  private final DatastoreService datastore;
-  private String displayName;
+  private DatastoreService datastore;
+  private static final String DISPLAY_NAME_QUERY_STRING = "display-name";
+  private static final String USER_ENTITY_QUERY_STRING = "UserInfo";
+  private static final String ID_QUERY_STRING = "id";
 
   public UserDatabase(DatastoreService datastore) {
     this.datastore = datastore;
   }
 
   public String getDisplayName(String userId) {
-      // todo: fetch correct entity from datastore, return that display name
-      return displayName;
+    Query query = new Query(USER_ENTITY_QUERY_STRING)
+        .setFilter(
+            new Query.FilterPredicate(ID_QUERY_STRING, Query.FilterOperator.EQUAL, userId));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    if (entity == null) {
+      return "";
+    }
+    return entity.getProperty(DISPLAY_NAME_QUERY_STRING).toString();
   }
 
   public void setDisplayName(String userId, String displayName) {
-    this.displayName = displayName;
+    Entity entity = createUserEntity(userId, displayName);
+    this.datastore.put(entity);
   }
+
+  private Entity createUserEntity(String userId, String displayName) {
+    Entity entity = new Entity(USER_ENTITY_QUERY_STRING, userId);
+    entity.setProperty(ID_QUERY_STRING, userId);
+    entity.setProperty(DISPLAY_NAME_QUERY_STRING, displayName);
+    return entity;
+  }
+
 }


### PR DESCRIPTION
Display names are now linked to the user id (created when user logs in), and stored in a datastore. The next step is to change the front-end so the display name is used on the comments page, and that there is a link to login on the comment page. Go to this link to test it out: http://zoebaker-step-2020.appspot.com/login.html (preferably in incognito mode).