### PR TITLE
Implementing meeting query method + unit tests

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,124 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.HashSet;
+import java.lang.Math;
 
+/** given a collection of existing meetings (with time ranges and attendees) and a request for 
+  * a meeting (with duration and mandatory/optional attendees), return the times when the meeting 
+  * could happen that day.
+**/
 public final class FindMeetingQuery {
+    private static final TimeRange START_OF_DAY_TIMERANGE =
+        TimeRange.fromStartDuration(TimeRange.START_OF_DAY, 0);
+    private static final TimeRange END_OF_DAY_TIMERANGE =
+        TimeRange.fromStartDuration(TimeRange.END_OF_DAY + 1, 0);
+
+  /** returns time ranges that will accomodate meeting request
+   *  if no time ranges exist all (mandatory + optional) attendees can attend, time ranges that
+   *  accomodate only mandatory attendees is returned instead if no mandatory time ranges exists 
+   *  that mandatory attendees can attend, an empty collection is returned. 
+  **/
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    Collection<TimeRange> allAttendeeTimeRanges = extractAttendingTimeRangesFromEvents(
+        events, request, /* include optional attendees= */ true);
+    Collection<TimeRange> acceptableOptionalTimeRanges = getConflictFreeTimeRanges(
+        allAttendeeTimeRanges, request);
+
+    if (request.getAttendees().isEmpty() || !acceptableOptionalTimeRanges.isEmpty()) {
+      return acceptableOptionalTimeRanges;
+    } else {
+      Collection<TimeRange> mandatoryAttendeeTimeRanges = extractAttendingTimeRangesFromEvents(
+          events, request, /* includes optional attendees= */ false);
+      Collection<TimeRange> acceptableMandatoryTimeRanges = getConflictFreeTimeRanges(
+          mandatoryAttendeeTimeRanges, request);
+      return acceptableMandatoryTimeRanges;
+    }
+  }
+  
+  /** given a collection of TimeRanges and a meeting request, returns 
+    * a collection of timeranges that the meeting can be scheduled in 
+    * without conflicts
+  **/
+  private Collection<TimeRange> getConflictFreeTimeRanges(
+      Collection<TimeRange> timeRanges, MeetingRequest request) {
+        
+    // edge case: if meeting request duration is too long, return empty list
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      return Arrays.asList();
+    }
+
+    // edge case: if there are no exisiting meetings, return entire day
+    if (timeRanges.isEmpty()) {
+      return Arrays.asList(TimeRange.WHOLE_DAY);
+    }
+    
+    List<TimeRange> timeRangesByStart = prepareAndSortTimeRanges(timeRanges);
+    
+    List<TimeRange> acceptableTimeRanges = new ArrayList<TimeRange>();
+    TimeRange currentMeetingTimeRange;
+    TimeRange nextMeetingTimeRange;
+
+    for (int timeRangeIndex= 0; timeRangeIndex< timeRangesByStart.size() - 1; timeRangeIndex++) {
+      currentMeetingTimeRange = timeRangesByStart.get(timeRangeIndex);  
+      nextMeetingTimeRange = timeRangesByStart.get(timeRangeIndex + 1);
+      // if overlap, merge with next meeting
+      if (currentMeetingTimeRange.overlaps(nextMeetingTimeRange)) {
+        timeRangesByStart.set(
+           timeRangeIndex+ 1, getMergedMeetingTimeRange(currentMeetingTimeRange, nextMeetingTimeRange));
+      } else if (canGapFitRequest(currentMeetingTimeRange.end(), nextMeetingTimeRange.start(), request)) { 
+        TimeRange accetableRange = TimeRange.fromStartEnd(
+            currentMeetingTimeRange.end(), nextMeetingTimeRange.start(), 
+            /* inclusive of end= */ false);
+        acceptableTimeRanges.add(accetableRange);
+      }
+    }
+    return acceptableTimeRanges;
+  }
+
+  /* Creates a collection of TimeRanges from the associated collection of Events */
+  private Collection<TimeRange> extractAttendingTimeRangesFromEvents(
+      Collection<Event> events, MeetingRequest request, boolean includeOptionalAttendees) {   
+    Collection<TimeRange> timeRanges = new ArrayList<TimeRange>();
+    Collection<String> requestedAttendees = new HashSet<String>();
+    requestedAttendees.addAll(request.getAttendees());
+    
+    if (includeOptionalAttendees) {
+      requestedAttendees.addAll(request.getOptionalAttendees());
+    } 
+
+    for (Event event : events) {
+      // only add events if they contain attendees that are requested for this meeting
+      if (!Collections.disjoint(requestedAttendees, event.getAttendees())) {
+        timeRanges.add(event.getWhen());
+      }
+    }
+    return timeRanges;
+  }
+  
+  /* Returns true if a gap between two time periods can fit in a meeting's duration*/
+  private boolean canGapFitRequest(
+      int earlierMeetingEnd, int latertimeRangeStart, MeetingRequest request){
+    return latertimeRangeStart - earlierMeetingEnd >= request.getDuration();
+  }
+
+  private TimeRange getMergedMeetingTimeRange(TimeRange meeting1, TimeRange meeting2) {
+    int newStart = Math.min(meeting1.start(), meeting2.start());
+    int newEnd = Math.max(meeting1.end(), meeting2.end());
+    return TimeRange.fromStartEnd(newStart, newEnd, /* inclusive of end= */ false);
+  }
+
+  private List<TimeRange> prepareAndSortTimeRanges(Collection<TimeRange> timeRanges) {
+    // add dummy events at start of day and end of day with no duration 
+    timeRanges.add(START_OF_DAY_TIMERANGE);
+    timeRanges.add(END_OF_DAY_TIMERANGE);
+    
+    List<TimeRange> timeRangesByStart = new ArrayList(timeRanges);
+    Collections.sort(timeRangesByStart, TimeRange.ORDER_BY_START);
+    return timeRangesByStart;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -41,13 +42,19 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
+  private static final int TIME_1030AM = TimeRange.getTimeInMinutes(10, 30);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
   private static final int DURATION_1_HOUR = 60;
   private static final int DURATION_2_HOUR = 120;
+
+  private static final String EVENT_1 = "Event 1";
+  private static final String EVENT_2 = "Event 2";
+  private static final String EVENT_3 = "Event 3";
 
   private FindMeetingQuery query;
 
@@ -81,7 +88,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
+    Collection<Event> events = Arrays.asList(new Event(EVENT_1,
         TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -104,9 +111,9 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|     |--2--|     |--3--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
@@ -131,9 +138,9 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
@@ -158,9 +165,9 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
@@ -184,9 +191,9 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -209,9 +216,9 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event(EVENT_1, TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event(EVENT_2, TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -227,7 +234,7 @@ public final class FindMeetingQueryTest {
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
+    Collection<Event> events = Arrays.asList(new Event(EVENT_1,
         TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
 
@@ -258,12 +265,166 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event(EVENT_1, TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event(EVENT_2, TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendee_withConflictingEvent_isNotScheduled() {
+    // Add an optional attendee C who has an all-day event. 
+    // Three time ranges should be returned which can accomadate all mandatory attendees
+    //
+    // Events  : |--------------C--------------|
+    //                 |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event(EVENT_3, TimeRange.WHOLE_DAY,
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendee_ScheduledReturnedThatAccomodates() {
+    // add an optional attendee C who has an event between 8:30 and 9:00. O
+    // Only the early and late parts of the day should be returned.
+    //
+    // Events  :             |--C--|
+    //                 |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event(EVENT_3, TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomForSingleOptionalAttendee() {
+    // Have one person who is mandatory (A), one person who is optional (B)
+    // There is just enough room for the mandatory attendee
+    // Events  : |--A--||B|  |----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event(EVENT_1, TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_2, TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_3, TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void multipleOptionalAttendees_WithRoomForMeeting() {
+    // Have mupliple optional attendees with gaps large enough to accomodate meeting.
+    //
+    // Events  :       |--A--|
+    //                    |--B--|
+    //                              |--C--|
+    // Day     : |------------------------|
+    // Options : |--1--|        |-2-|
+
+    Collection<Event> events = Arrays.asList(
+        new Event(EVENT_1, TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0930AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event(EVENT_3, TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_1030AM, TIME_1100AM, false));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void multipleOptionalAttendees_dontHaveRoomForMeeting() {
+    // Have mupliple optional attendees with no gaps, should return no times to meet
+    //
+    // Events  : |----A----|
+    //                        |--C--|
+    //                   |--B--|
+    // Day     : |------------------|
+    // Options : |--1--|        |-2-|
+
+    Collection<Event> events = Arrays.asList(
+        new Event(EVENT_1, TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event(EVENT_2, TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event(EVENT_3, TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+    request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
Implemented the query() method of FindMeetingQuery.java. The goal of this method is that, given a collection of existing meetings (with time ranges and attendees) and a request for a meeting (with duration and mandatory/optional attendees), return the times when the meeting could happen that day. 

The walkthrough had already implemented some existing tests, and asked us to write some more tests at the end. 